### PR TITLE
Add endpoints to favorite universities

### DIFF
--- a/Database/Migrations/20231216032215-create_favorite_university.js
+++ b/Database/Migrations/20231216032215-create_favorite_university.js
@@ -1,0 +1,41 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("favorite_university", {
+      createdAt: Sequelize.DATE,
+      universityId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+        references: {
+          model: "university",
+          key: "id",
+        },
+      },
+      updatedAt: Sequelize.DATE,
+      userId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+        references: {
+          model: "user",
+          key: "id",
+        },
+      },
+    });
+
+    await queryInterface.addIndex("favorite_university", ["userId"]);
+    await queryInterface.addIndex("favorite_university", ["universityId"]);
+
+    await queryInterface.addConstraint("favorite_university", {
+      fields: ["userId", "universityId"],
+      type: "unique",
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("favorite_university");
+  },
+};

--- a/Database/Model/FavoriteUniversity.js
+++ b/Database/Model/FavoriteUniversity.js
@@ -1,0 +1,47 @@
+const sequelize = require("sequelize");
+
+const db = require("../Connect");
+
+const University = require("./University");
+const User = require("./User");
+
+const FavoriteUniversity = db.define(
+  "FavoriteUniversity",
+  {
+    universityId: {
+      type: sequelize.INTEGER,
+      primaryKey: true,
+      allowNull: false,
+      references: {
+        model: University,
+        key: "id",
+      },
+    },
+    userId: {
+      type: sequelize.INTEGER,
+      primaryKey: true,
+      allowNull: false,
+      references: {
+        model: User,
+        key: "id",
+      },
+    },
+  },
+  {
+    tableName: "favorite_university",
+    timestamps: true,
+    freezeTableName: true,
+  }
+);
+
+FavoriteUniversity.hasOne(University, {
+  foreignKey: "id",
+  sourceKey: "universityId",
+});
+
+FavoriteUniversity.hasOne(User, {
+  foreignKey: "id",
+  sourceKey: "userId",
+});
+
+module.exports = FavoriteUniversity;

--- a/Middleware/require-session.js
+++ b/Middleware/require-session.js
@@ -1,0 +1,17 @@
+module.exports = (isRequired = true) => {
+  return (req, res, next) => {
+    if (isRequired && !req.session.user) {
+      return res.status(401).json({
+        message: "You are not logged in.",
+      });
+    }
+
+    if (!isRequired && req.session.user) {
+      return res.status(403).json({
+        message: "You are already logged in.",
+      });
+    }
+
+    next();
+  };
+};

--- a/Route/favorites.js
+++ b/Route/favorites.js
@@ -1,0 +1,77 @@
+const express = require("express");
+const z = require("zod");
+
+const FavoriteUniversity = require("../Database/Model/FavoriteUniversity");
+const University = require("../Database/Model/University");
+
+const requireSession = require("../Middleware/require-session");
+const validateBody = require("../Middleware/validate-body");
+
+const router = express.Router();
+
+router.use(requireSession());
+
+router.get("/", async (req, res) => {
+  const favorites = await FavoriteUniversity.findAll({
+    include: University,
+    where: {
+      userId: req.session.user.id,
+    },
+  });
+
+  res.json({
+    favorites: favorites.map((favorite) => favorite.University),
+  });
+});
+
+router.delete("/:id", async (req, res) => {
+  const favorite = await FavoriteUniversity.findOne({
+    where: {
+      universityId: req.params.id,
+      userId: req.session.user.id,
+    },
+  });
+
+  if (!favorite) {
+    return res.status(404).json({
+      message: "Favorite not found.",
+    });
+  }
+
+  await favorite.destroy();
+
+  res.status(204).end();
+});
+
+router.post(
+  "/",
+  validateBody(
+    z.object({
+      universityId: z.number().int().positive(),
+    })
+  ),
+  async (req, res) => {
+    const alreadyFavorited = await FavoriteUniversity.findOne({
+      include: University,
+      where: {
+        universityId: req.body.universityId,
+        userId: req.session.user.id,
+      },
+    });
+
+    if (alreadyFavorited) {
+      return res.status(403).json({
+        message: `You have already favorited ${alreadyFavorited.University.university_name}.`,
+      });
+    }
+
+    await FavoriteUniversity.create({
+      universityId: req.body.universityId,
+      userId: req.session.user.id,
+    });
+
+    res.status(204).end();
+  }
+);
+
+module.exports = router;

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ app.use(
 );
 
 app.use("/auth", require("./Route/auth"));
+app.use("/favorites", require("./Route/favorites"));
 app.use("/university", require("./Route/university"));
 
 db.authenticate().then(() => {


### PR DESCRIPTION
Added endpoints to retrieve, favorite, and unfavorite universities. All endpoints require the user to be logged in.

`GET /favorites`: Retrieves all favorited universities for the current user.
`POST /favorites`: Adds a new favorite university for the current user. If the user has already added the university as a favorite, then a 403 is returned.
`DELETE /favorites/:universityId`: Unfavorites a university by its ID for the current user. If the user has not added the specified university as a favorite, a 404 is returned.