### PR TITLE
Add @me endpoint and separate into its own router

### DIFF
--- a/Route/@me.js
+++ b/Route/@me.js
@@ -112,3 +112,5 @@ router.patch(
     res.status(204).end();
   }
 );
+
+module.exports = router;

--- a/Route/@me.js
+++ b/Route/@me.js
@@ -1,0 +1,114 @@
+const express = require("express");
+const z = require("zod");
+
+const db = require("../Database/Connect");
+
+const FavoriteUniversity = require("../Database/Model/FavoriteUniversity");
+const Users = require("../Database/Model/User");
+
+const requireSession = require("../Middleware/require-session");
+const validateBody = require("../Middleware/validate-body");
+
+const router = express.Router();
+
+router.use(requireSession());
+
+router.get("/", (req, res) => {
+  res.json({
+    user: {
+      email: req.session.user.email,
+      firstName: req.session.user.firstName,
+      id: req.session.user.id,
+      lastName: req.session.user.lastName,
+    },
+  });
+});
+
+router.delete(
+  "/",
+  validateBody(
+    z.object({
+      password: z.string().min(1),
+    })
+  ),
+  async (req, res) => {
+    const user = await Users.findOne({
+      where: {
+        id: req.session.user.id,
+      },
+    });
+
+    if (!user) {
+      throw new Error(`User with ID ${req.session.user.id} not found.`);
+    }
+
+    const isPasswordValid = await user.validatePassword(req.body.password);
+
+    if (!isPasswordValid) {
+      return res.status(401).json({
+        message: "Incorrect password provided.",
+      });
+    }
+
+    await db.transaction(async (transaction) => {
+      await FavoriteUniversity.destroy(
+        {
+          where: {
+            userId: req.session.user.id,
+          },
+        },
+        {
+          transaction,
+        }
+      );
+
+      await Users.destroy(
+        {
+          where: {
+            id: req.session.user.id,
+          },
+        },
+        {
+          transaction,
+        }
+      );
+
+      res.status(204).end();
+    });
+  }
+);
+
+router.patch(
+  "/change-password",
+  validateBody(
+    z.object({
+      newPassword: z.string().min(1),
+      oldPassword: z.string().min(1),
+    })
+  ),
+  async (req, res) => {
+    const user = await Users.findOne({
+      where: {
+        id: req.session.user.id,
+      },
+    });
+
+    if (!user) {
+      throw new Error(`User with ID ${req.session.user.id} not found.`);
+    }
+
+    const isPasswordValid = await user.validatePassword(req.body.oldPassword);
+
+    if (!isPasswordValid) {
+      return res.status(401).json({
+        message: "Incorrect password provided.",
+      });
+    }
+
+    await user.update({
+      password: req.body.newPassword,
+    });
+
+    res.status(204).end();
+  }
+);

--- a/Route/auth.js
+++ b/Route/auth.js
@@ -1,23 +1,12 @@
 const express = require("express");
 const z = require("zod");
 
-const users = require("../Database/Model/User");
+const Users = require("../Database/Model/User");
 
 const requireSession = require("../Middleware/require-session");
 const validateBody = require("../Middleware/validate-body");
 
 const router = express.Router();
-
-router.get("/@me", requireSession(), (req, res) => {
-  res.json({
-    user: {
-      email: req.session.user.email,
-      firstName: req.session.user.firstName,
-      id: req.session.user.id,
-      lastName: req.session.user.lastName,
-    },
-  });
-});
 
 router.post(
   "/login",
@@ -31,7 +20,7 @@ router.post(
   async (req, res, next) => {
     const { email, password } = req.body;
 
-    const user = await users.findOne({
+    const user = await Users.findOne({
       where: {
         email,
       },
@@ -71,7 +60,7 @@ router.post(
   }
 );
 
-router.post("/logout", requireSession(), (req, res) => {
+router.delete("/logout", requireSession(), (req, res) => {
   req.session.destroy((error) => {
     if (error) {
       return next(error);
@@ -95,7 +84,7 @@ router.post(
   async (req, res, next) => {
     const { firstName, lastName, email, password } = req.body;
 
-    const existingUser = await users.findOne({
+    const existingUser = await Users.findOne({
       where: {
         email,
       },
@@ -107,7 +96,7 @@ router.post(
       });
     }
 
-    const user = await users.create({
+    const user = await Users.create({
       firstName,
       lastName,
       email,

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ app.use(
 );
 
 app.use("/auth", require("./Route/auth"));
+app.use("/@me", require("./Route/@me"));
 app.use("/favorites", require("./Route/favorites"));
 app.use("/university", require("./Route/university"));
 


### PR DESCRIPTION
Refactored routers so that `/auth/@me` is now just `/@me`. Also added 2 new endpoints:

`GET /@me`: Returns the currently logged-in user, just like `GET /auth/@me` did.
`DELETE /@me`: Deletes the account of the currently logged-in user. Requires the user's password to confirm the deletion.
`PATCH /@me/change-password`: Change the password of the currently logged-in user. Requires the user's old password to authorize the change.