### PR TITLE
Add ability to rank favorites

### DIFF
--- a/Database/Migrations/20231216050636-add_favorite_rankings.js
+++ b/Database/Migrations/20231216050636-add_favorite_rankings.js
@@ -14,6 +14,10 @@ module.exports = {
       allowNull: false,
       defaultValue: 1,
     });
+
+    await queryInterface.changeColumn("favorite_university", "rank", {
+      defaultValue: null,
+    });
   },
 
   async down(queryInterface, Sequelize) {

--- a/Database/Migrations/20231216050636-add_favorite_rankings.js
+++ b/Database/Migrations/20231216050636-add_favorite_rankings.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.addColumn("favorite_university", "rank", {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+    await queryInterface.removeColumn("favorite_university", "rank");
+  },
+};

--- a/Database/Model/FavoriteUniversity.js
+++ b/Database/Model/FavoriteUniversity.js
@@ -8,6 +8,10 @@ const User = require("./User");
 const FavoriteUniversity = db.define(
   "FavoriteUniversity",
   {
+    rank: {
+      type: sequelize.INTEGER,
+      allowNull: false,
+    },
     universityId: {
       type: sequelize.INTEGER,
       primaryKey: true,

--- a/Route/favorites.js
+++ b/Route/favorites.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const z = require("zod");
 
+const db = require("../Database/Connect");
+
 const FavoriteUniversity = require("../Database/Model/FavoriteUniversity");
 const University = require("../Database/Model/University");
 
@@ -14,6 +16,7 @@ router.use(requireUser());
 router.get("/", async (req, res) => {
   const favorites = await FavoriteUniversity.findAll({
     include: University,
+    order: [["rank", "ASC"]],
     where: {
       userId: req.user.id,
     },
@@ -22,25 +25,6 @@ router.get("/", async (req, res) => {
   res.json({
     favorites: favorites.map((favorite) => favorite.University),
   });
-});
-
-router.delete("/:id", async (req, res) => {
-  const favorite = await FavoriteUniversity.findOne({
-    where: {
-      universityId: req.params.id,
-      userId: req.user.id,
-    },
-  });
-
-  if (!favorite) {
-    return res.status(404).json({
-      message: "Favorite not found.",
-    });
-  }
-
-  await favorite.destroy();
-
-  res.status(204).end();
 });
 
 router.post(
@@ -65,9 +49,104 @@ router.post(
       });
     }
 
+    const nextRank = await FavoriteUniversity.count({
+      where: {
+        userId: req.user.id,
+      },
+    });
+
     await FavoriteUniversity.create({
+      rank: nextRank + 1,
       universityId: req.body.universityId,
       userId: req.user.id,
+    });
+
+    res.status(204).end();
+  }
+);
+
+router.delete("/:id", async (req, res) => {
+  const favorite = await FavoriteUniversity.findOne({
+    where: {
+      universityId: req.params.id,
+      userId: req.user.id,
+    },
+  });
+
+  if (!favorite) {
+    return res.status(404).json({
+      message: "Favorite not found.",
+    });
+  }
+
+  await favorite.destroy();
+
+  res.status(204).end();
+});
+
+router.patch(
+  "/:id/rank",
+  validateBody(
+    z.object({
+      newRank: z.number().int().positive().gte(1),
+    })
+  ),
+  async (req, res) => {
+    const { newRank } = req.body;
+
+    const maxRank = await FavoriteUniversity.count({
+      where: {
+        userId: req.user.id,
+      },
+    });
+
+    if (newRank > maxRank) {
+      return res.status(400).json({
+        message: `New rank must be between 1 and ${maxRank}.`,
+      });
+    }
+
+    const [destinationFavorite, sourceFavorite] = await Promise.all([
+      FavoriteUniversity.findOne({
+        where: {
+          rank: newRank,
+          userId: req.user.id,
+        },
+      }),
+      FavoriteUniversity.findOne({
+        where: {
+          universityId: req.params.id,
+          userId: req.user.id,
+        },
+      }),
+    ]);
+
+    if (!sourceFavorite) {
+      return res.status(404).json({
+        message: `University with ID ${req.params.id} not found in favorites.`,
+      });
+    }
+
+    await db.transaction(async (transaction) => {
+      if (destinationFavorite) {
+        await destinationFavorite.update(
+          {
+            rank: sourceFavorite.rank,
+          },
+          {
+            transaction,
+          }
+        );
+      }
+
+      await sourceFavorite.update(
+        {
+          rank: newRank,
+        },
+        {
+          transaction,
+        }
+      );
     });
 
     res.status(204).end();


### PR DESCRIPTION
Adds support for ranking favorites. By default, new favorites will be added to the bottom of the rankings. 

`GET /favorites` will now return favorites ranked in the user's preference.
`PATCH /favorites/:universityId/rank` allows you to swap the rank with another university that is favorited by the current user.